### PR TITLE
Fix of publish:all fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .vscode
 .DS_Store
+.pnpm-store
+report


### PR DESCRIPTION
Add folders to gitignore. They are generated at pipeline run and cause publish task to fail