### PR TITLE
Move `jsbi` to direct dependencies from peers

### DIFF
--- a/e2e-spa/package.json
+++ b/e2e-spa/package.json
@@ -12,7 +12,6 @@
     "dependencies": {
         "@scale-codec/definition-runtime": "link:../packages/definition-runtime",
         "fast-deep-equal": "^3.1.3",
-        "jsbi": "^3.1.5",
         "vue": "^3.1.4"
     },
     "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -6,7 +6,7 @@ Codecs for primitives and main containers according to the SCALE specification.
 
 ```sh
 # Use your favorite PM
-npm install @scale-codec/core jsbi
+npm install @scale-codec/core
 ```
 
 ### Supported types

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@scale-codec/core",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Implementations of core SCALE-codec primitives and data structures",
     "license": "Apache-2.0",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,16 +30,13 @@
     },
     "dependencies": {
         "@scale-codec/enum": "workspace:^0.1.0",
-        "@scale-codec/util": "workspace:^0.1.0"
+        "@scale-codec/util": "workspace:^0.1.0",
+        "jsbi": "3.2.4"
     },
     "devDependencies": {
         "hada": "^0.0.8",
         "http-server": "^0.12.3",
-        "jsbi": "^3.1.5",
         "type-fest": "^1.2.0",
         "typedoc": "^0.20.36"
-    },
-    "peerDependencies": {
-        "jsbi": "^3.1.5"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,6 @@ importers:
       esno: ^0.8.0
       fast-deep-equal: ^3.1.3
       jest: ^27.0.6
-      jsbi: ^3.1.5
       rimraf: ^3.0.2
       start-server-and-test: ^1.12.5
       typescript: ^4.3.5
@@ -90,7 +89,6 @@ importers:
     dependencies:
       '@scale-codec/definition-runtime': link:../packages/definition-runtime
       fast-deep-equal: 3.1.3
-      jsbi: 3.1.5
       vue: 3.1.4
     devDependencies:
       '@jest/types': 27.0.6
@@ -103,7 +101,7 @@ importers:
       cypress: 7.6.0
       esbuild-jest: 0.5.0
       esno: 0.8.0
-      jest: 27.0.6_ts-node@10.0.0
+      jest: 27.0.6
       rimraf: 3.0.2
       start-server-and-test: 1.12.5
       typescript: 4.3.5
@@ -115,16 +113,16 @@ importers:
       '@scale-codec/util': workspace:^0.1.0
       hada: ^0.0.8
       http-server: ^0.12.3
-      jsbi: ^3.1.5
+      jsbi: 3.2.4
       type-fest: ^1.2.0
       typedoc: ^0.20.36
     dependencies:
       '@scale-codec/enum': link:../enum
       '@scale-codec/util': link:../util
+      jsbi: 3.2.4
     devDependencies:
       hada: 0.0.8
       http-server: 0.12.3
-      jsbi: 3.1.5
       type-fest: 1.2.0
       typedoc: 0.20.36_typescript@4.3.5
 
@@ -919,6 +917,52 @@ packages:
       jest-message-util: 27.0.6
       jest-util: 27.0.6
       slash: 3.0.0
+    dev: true
+
+  /@jest/core/27.0.6:
+    resolution: {integrity: sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 27.0.6
+      '@jest/reporters': 27.0.6
+      '@jest/test-result': 27.0.6
+      '@jest/transform': 27.0.6
+      '@jest/types': 27.0.6
+      '@types/node': 16.0.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.1
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      jest-changed-files: 27.0.6
+      jest-config: 27.0.6
+      jest-haste-map: 27.0.6
+      jest-message-util: 27.0.6
+      jest-regex-util: 27.0.6
+      jest-resolve: 27.0.6
+      jest-resolve-dependencies: 27.0.6
+      jest-runner: 27.0.6
+      jest-runtime: 27.0.6
+      jest-snapshot: 27.0.6
+      jest-util: 27.0.6
+      jest-validate: 27.0.6
+      jest-watcher: 27.0.6
+      micromatch: 4.0.4
+      p-each-series: 2.2.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
 
   /@jest/core/27.0.6_ts-node@10.0.0:
@@ -4428,6 +4472,36 @@ packages:
       - supports-color
     dev: true
 
+  /jest-cli/27.0.6:
+    resolution: {integrity: sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.0.6
+      '@jest/test-result': 27.0.6
+      '@jest/types': 27.0.6
+      chalk: 4.1.1
+      exit: 0.1.2
+      graceful-fs: 4.2.6
+      import-local: 3.0.2
+      jest-config: 27.0.6
+      jest-util: 27.0.6
+      jest-validate: 27.0.6
+      prompts: 2.4.1
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /jest-cli/27.0.6_ts-node@10.0.0:
     resolution: {integrity: sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4455,6 +4529,43 @@ packages:
       - canvas
       - supports-color
       - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest-config/27.0.6:
+    resolution: {integrity: sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.14.6
+      '@jest/test-sequencer': 27.0.6
+      '@jest/types': 27.0.6
+      babel-jest: 27.0.6_@babel+core@7.14.6
+      chalk: 4.1.1
+      deepmerge: 4.2.2
+      glob: 7.1.7
+      graceful-fs: 4.2.6
+      is-ci: 3.0.0
+      jest-circus: 27.0.6
+      jest-environment-jsdom: 27.0.6
+      jest-environment-node: 27.0.6
+      jest-get-type: 27.0.6
+      jest-jasmine2: 27.0.6
+      jest-regex-util: 27.0.6
+      jest-resolve: 27.0.6
+      jest-runner: 27.0.6
+      jest-util: 27.0.6
+      jest-validate: 27.0.6
+      micromatch: 4.0.4
+      pretty-format: 27.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
       - utf-8-validate
     dev: true
 
@@ -4912,6 +5023,27 @@ packages:
       supports-color: 8.1.1
     dev: true
 
+  /jest/27.0.6:
+    resolution: {integrity: sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.0.6
+      import-local: 3.0.2
+      jest-cli: 27.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /jest/27.0.6_ts-node@10.0.0:
     resolution: {integrity: sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -4962,6 +5094,11 @@ packages:
 
   /jsbi/3.1.5:
     resolution: {integrity: sha512-w2BY0VOYC1ahe+w6Qhl4SFoPvPsZ9NPHY4bwass+LCgU7RK3PBoVQlQ3G1s7vI8W3CYyJiEXcbKF7FIM/L8q3Q==}
+    dev: true
+
+  /jsbi/3.2.4:
+    resolution: {integrity: sha512-iOygwxPzMYli5xrjfd83Vy4Wyu9Ovpw6wWWFy5Kj7XP+pZxPp7Cy72F92iAt2j+6tTDYunvLtC+2tH3xCX37ng==}
+    dev: false
 
   /jsbn/0.1.1:
     resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}


### PR DESCRIPTION
The `JSBI` is re-exported from `@scale-codec/core` library sinse `0.2.0` and it is a direct dependency.