### PR TITLE
DOPS-1511: add gh-actions workflow for gh-pages

### DIFF
--- a/.github/workflows/ghpages-deploy.yml
+++ b/.github/workflows/ghpages-deploy.yml
@@ -1,0 +1,49 @@
+name: CD
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2.0.1
+      with:
+        version: 6.19.0
+
+    - name: Install packages
+      run: pnpm install
+
+    - name: Build application
+      run: pnpm run build
+      env:
+        PUBLIC_PATH: /scale-codec-js-library/
+
+    - name: deploy application
+      run: pnpm docs:build
+
+    - name: Init git repo in 'dist'
+      working-directory: ./dist
+      run: |
+        git config --global user.email "${GITHUB_ACTOR}@https://users.noreply.github.com/"
+        git config --global user.name "${GITHUB_ACTOR}"
+        git init
+        git add --all
+        git commit -m "Auto update pages on $(date +'%Y-%m-%d %H:%M:%S')"
+
+    - name: Push to master:gh-pages
+      working-directory: ./dist
+      run: |
+        git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} master:gh-pages


### PR DESCRIPTION
# Task

[DOPS-1511]: Setup docs publishing for `scale-codec-js-library`
## Changes

1. add initial gh-actions workflow for gh-pages

## Author

Signed-off-by: Vasilii Zyabkin <vzyabkin@soramitsu.co.jp>


[DOPS-1511]: https://soramitsu.atlassian.net/browse/DOPS-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ