### PR TITLE
[fix]: use `.cjs` & `.mjs` extensions for build artifacts

### DIFF
--- a/.changeset/quiet-chefs-invent.md
+++ b/.changeset/quiet-chefs-invent.md
@@ -1,9 +1,0 @@
----
-'@scale-codec/core': minor
-'@scale-codec/definition-compiler': minor
-'@scale-codec/definition-runtime': minor
-'@scale-codec/enum': minor
-'@scale-codec/util': minor
----
-
-Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`

--- a/.changeset/quiet-chefs-invent.md
+++ b/.changeset/quiet-chefs-invent.md
@@ -1,0 +1,9 @@
+---
+'@scale-codec/core': minor
+'@scale-codec/definition-compiler': minor
+'@scale-codec/definition-runtime': minor
+'@scale-codec/enum': minor
+'@scale-codec/util': minor
+---
+
+Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`

--- a/e2e-spa/README.md
+++ b/e2e-spa/README.md
@@ -11,7 +11,7 @@ Includes:
 
 Hacks used to ensure that finally published libraries really work:
 
-- Direct usage of `dist/lib.cjs.js` of `@scale-codec/definition-compiler` within `gulpfile.ts`
+- Direct usage of `dist/lib.cjs` of `@scale-codec/definition-compiler` within `gulpfile.ts`
 - Aliasing to `./runtime-rollup/index.cjs.js` from `@scale-codec/definition-runtime` within `jest.config.js`
 - Aliasing to `./runtime-rollup/index.esm.js` from `@scale-codec/definition-runtime` within `vite.config.ts`
 

--- a/e2e-spa/README.md
+++ b/e2e-spa/README.md
@@ -11,7 +11,7 @@ Includes:
 
 Hacks used to ensure that finally published libraries really work:
 
-- Direct usage of `dist/lib.cjs` of `@scale-codec/definition-compiler` within `gulpfile.ts`
+- Direct usage of `dist/lib.cjs` of `@scale-codec/definition-compiler` within Jakefile
 - Aliasing to `./runtime-rollup/index.cjs.js` from `@scale-codec/definition-runtime` within `jest.config.js`
 - Aliasing to `./runtime-rollup/index.esm.js` from `@scale-codec/definition-runtime` within `vite.config.ts`
 

--- a/e2e-spa/etc/jakefile.ts
+++ b/e2e-spa/etc/jakefile.ts
@@ -8,9 +8,9 @@ import definition from './__definition__'
 
 // doing a typing trick to use actual CommonJS build
 // dist/lib.cjs is untyped
-import * as compilerLib from '@scale-codec/definition-compiler'
+import type * as CompilerLibType from '@scale-codec/definition-compiler'
 import * as compilerLibCjs from '@scale-codec/definition-compiler/dist/lib.cjs'
-const { renderNamespaceDefinition } = compilerLibCjs as typeof compilerLib
+const { renderNamespaceDefinition } = compilerLibCjs as typeof CompilerLibType
 
 const resolve = (...paths: string[]) => path.resolve(__dirname, '../', ...paths)
 const NAMESPACE_OUT_FILE = resolve('src/namespace.ts')

--- a/e2e-spa/package.json
+++ b/e2e-spa/package.json
@@ -14,8 +14,8 @@
   },
   "devDependencies": {
     "@esbuild-kit/cjs-loader": "^2.0.1",
-    "@scale-codec/definition-compiler": "workspace:^2.0.0",
-    "@scale-codec/definition-runtime": "workspace:^2.0.0",
+    "@scale-codec/definition-compiler": "workspace:^2.2.0",
+    "@scale-codec/definition-runtime": "workspace:^2.2.0",
     "@types/jake": "^0.0.33",
     "@vitejs/plugin-vue": "^2.3.3",
     "@vue/compiler-sfc": "^3.2.36",

--- a/etc/jakefile.ts
+++ b/etc/jakefile.ts
@@ -180,7 +180,7 @@ task('bundle', ['clean'], async () => {
     for (const format of ['esm', 'cjs'] as const) {
       await esbuild.build({
         entryPoints: [resolvePackageEntrypoint(unscopedPackageName)],
-        outfile: path.join(resolvePackageDist(unscopedPackageName), `lib.${format}.js`),
+        outfile: path.join(resolvePackageDist(unscopedPackageName), `lib.${format === 'esm' ? 'mjs' : 'cjs'}`),
         bundle: true,
         external: PACKAGE_EXTERNALS[unscopedPackageName],
         logLevel: 'info',

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-vue": "^9.0.1",
     "fs-extra": "^10.1.0",
     "jake": "^10.8.5",
-    "jest-immutable-matchers": "^3.0.0",
     "prettier": "^2.6.2",
     "prettier-eslint": "^15.0.1",
     "prettier-eslint-cli": "^6.0.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,160 +1,172 @@
 # @scale-codec/core
 
+## 1.1.0
+
+### Minor Changes
+
+- e72d4de: Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`
+
+### Patch Changes
+
+- Updated dependencies [e72d4de]
+  - @scale-codec/enum@1.1.0
+  - @scale-codec/util@1.1.0
+
 ## 1.0.1
 
 ### Patch Changes
 
--   1f92e19: **types**: remove `DecudeResult` from doc comments
--   Updated dependencies [1f92e19]
-    -   @scale-codec/enum@1.0.2
+- 1f92e19: **types**: remove `DecudeResult` from doc comments
+- Updated dependencies [1f92e19]
+  - @scale-codec/enum@1.0.2
 
 ## 1.0.0
 
 ### Major Changes
 
--   **BREAKING**: refactor all codecs, use new encoding & decoding approach
+- **BREAKING**: refactor all codecs, use new encoding & decoding approach
 
-    -   **What is the change**
+  - **What is the change**
 
-        Previously this package was built on the top of these core types:
+    Previously this package was built on the top of these core types:
 
-        ```ts
-        type Encode<T> = (value: T) => Uint8Array
+    ```ts
+    type Encode<T> = (value: T) => Uint8Array
 
-        type Decode<T> = (input: Uint8Array) => DecodeResult<T>
+    type Decode<T> = (input: Uint8Array) => DecodeResult<T>
 
-        type DecodeResult<T> = [value: T, bytesDecoded: number]
-        ```
+    type DecodeResult<T> = [value: T, bytesDecoded: number]
+    ```
 
-        While encoding, each codec was creating it's own `Uint8Array` instance that is concatenated with other ones. It produces a huge performace goal, because you create a lot of intermediate objects, a lot of memory is allocated during the encoding process.
+    While encoding, each codec was creating it's own `Uint8Array` instance that is concatenated with other ones. It produces a huge performace goal, because you create a lot of intermediate objects, a lot of memory is allocated during the encoding process.
 
-        Now this package is build on the top of these types:
+    Now this package is build on the top of these types:
 
-        ```ts
-        interface Walker {
-            u8: Uint8Array
-            // current walker offset
-            idx: number
-            // DataView associated with `u8`. Useful for (u)ints
-            view: DataView
-        }
+    ```ts
+    interface Walker {
+      u8: Uint8Array
+      // current walker offset
+      idx: number
+      // DataView associated with `u8`. Useful for (u)ints
+      view: DataView
+    }
 
-        interface Encode<T> {
-            (value: T, walker: Walker): void
-            sizeHint: (value: T) => number
-        }
+    interface Encode<T> {
+      (value: T, walker: Walker): void
+      sizeHint: (value: T) => number
+    }
 
-        type Decode<T> = (walker: Walker) => T
-        ```
+    type Decode<T> = (walker: Walker) => T
+    ```
 
-        With a special `Walker` type codecs now are much more performant and writing/reading data without a lot of additional allocations, but they are now much less functional and "pure".
+    With a special `Walker` type codecs now are much more performant and writing/reading data without a lot of additional allocations, but they are now much less functional and "pure".
 
-        With size hints its now possible to allocate buffer only once.
+    With size hints its now possible to allocate buffer only once.
 
-    -   **Why the change was made**
+  - **Why the change was made**
 
-        This change increases performance incredibly.
+    This change increases performance incredibly.
 
-    -   **How to migrate existing code**
+  - **How to migrate existing code**
 
-        The library exports special `WalkerImpl` utility class to work with codecs. For example, if previously to encode an array of strings, you were doing it like this:
+    The library exports special `WalkerImpl` utility class to work with codecs. For example, if previously to encode an array of strings, you were doing it like this:
 
-        ```ts
-        import { encodeArray, encodeStr } from '@scale-codec/core'
+    ```ts
+    import { encodeArray, encodeStr } from '@scale-codec/core'
 
-        const encoded = encodeArray(
-            [
-                /* ... */
-            ],
-            encodeStr,
-            32,
-        )
-        ```
+    const encoded = encodeArray(
+      [
+        /* ... */
+      ],
+      encodeStr,
+      32,
+    )
+    ```
 
-        Now the same action you can perform in this way:
+    Now the same action you can perform in this way:
 
-        ```ts
-        import { createArrayEncoder, encodeStr, WalkerImpl } from '@scale-codec/core'
+    ```ts
+    import { createArrayEncoder, encodeStr, WalkerImpl } from '@scale-codec/core'
 
-        const encoder = createArrayEncoder(encodeStr, 32)
+    const encoder = createArrayEncoder(encodeStr, 32)
 
-        const encoded = WalkerImpl.encode(
-            [
-                /* ... */
-            ],
-            encoder,
-        )
-        ```
+    const encoded = WalkerImpl.encode(
+      [
+        /* ... */
+      ],
+      encoder,
+    )
+    ```
 
 ### Patch Changes
 
--   Updated dependencies
--   Updated dependencies
--   Updated dependencies
-    -   @scale-codec/util@1.0.0
-    -   @scale-codec/enum@1.0.0
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @scale-codec/util@1.0.0
+  - @scale-codec/enum@1.0.0
 
 ## 0.4.2
 
 ### Patch Changes
 
--   c944775: **feat**: throw meaningfull errors if there are some problems with enum encoders/decoders schema (`encodeEnum` & `decodeEnum`)
--   Updated dependencies [b4c91cf]
-    -   @scale-codec/enum@0.2.2
+- c944775: **feat**: throw meaningfull errors if there are some problems with enum encoders/decoders schema (`encodeEnum` & `decodeEnum`)
+- Updated dependencies [b4c91cf]
+  - @scale-codec/enum@0.2.2
 
 ## 0.4.1
 
 ### Patch Changes
 
--   27b7927: Add build status badge to the README
--   Updated dependencies [27b7927]
-    -   @scale-codec/enum@0.2.1
-    -   @scale-codec/util@0.1.3
+- 27b7927: Add build status badge to the README
+- Updated dependencies [27b7927]
+  - @scale-codec/enum@0.2.1
+  - @scale-codec/util@0.1.3
 
 ## 0.4.0
 
 ### Minor Changes
 
--   8890415: **breaking**: drop `jsbi` replacement for native bigints, use native ones. Int & Compact codecs are completely refactored.
+- 8890415: **breaking**: drop `jsbi` replacement for native bigints, use native ones. Int & Compact codecs are completely refactored.
 
 ### Patch Changes
 
--   56a9d2c: Update readme & description in package.json
+- 56a9d2c: Update readme & description in package.json
 
 ## 0.3.0
 
 ### Minor Changes
 
--   97dfb7d: **Breaking**: rename `encodeStrCompact`& `encodeStr` to `encodeStr` & `encodeStrRaw` relatively (same for `decodeStr*`)
+- 97dfb7d: **Breaking**: rename `encodeStrCompact`& `encodeStr` to `encodeStr` & `encodeStrRaw` relatively (same for `decodeStr*`)
 
 ### Patch Changes
 
--   26c9dd0: Update readme and `homepage` at `package.json`
--   97dfb7d: Update doc comments, error messages and str encoding internals
--   6d26250: Bump `jsbi` package to `4.0.0`
--   ab6d899: Update typings for Enum encode/decode
--   334a28d: Add keywords to package.json
--   c78d861: Update usage of `Enum`
--   Updated dependencies [26c9dd0]
--   Updated dependencies [c78d861]
--   Updated dependencies [334a28d]
-    -   @scale-codec/enum@0.2.0
-    -   @scale-codec/util@0.1.2
+- 26c9dd0: Update readme and `homepage` at `package.json`
+- 97dfb7d: Update doc comments, error messages and str encoding internals
+- 6d26250: Bump `jsbi` package to `4.0.0`
+- ab6d899: Update typings for Enum encode/decode
+- 334a28d: Add keywords to package.json
+- c78d861: Update usage of `Enum`
+- Updated dependencies [26c9dd0]
+- Updated dependencies [c78d861]
+- Updated dependencies [334a28d]
+  - @scale-codec/enum@0.2.0
+  - @scale-codec/util@0.1.2
 
 ## 0.2.3
 
 ### Patch Changes
 
--   86cf787: fix: throw an error when the `encodeBigInt` is called with `signed: false` and negative number as source
--   e1598bb: Add a bit more detailed docs
--   a3d7d34: Set `engines` and `engineStrict` fields in core's `package.json`
--   Updated dependencies [b79934e]
--   Updated dependencies [7b92045]
-    -   @scale-codec/enum@0.1.1
-    -   @scale-codec/util@0.1.1
+- 86cf787: fix: throw an error when the `encodeBigInt` is called with `signed: false` and negative number as source
+- e1598bb: Add a bit more detailed docs
+- a3d7d34: Set `engines` and `engineStrict` fields in core's `package.json`
+- Updated dependencies [b79934e]
+- Updated dependencies [7b92045]
+  - @scale-codec/enum@0.1.1
+  - @scale-codec/util@0.1.1
 
 ## 0.2.2
 
 ### Patch Changes
 
--   cfec796: Update dependencies
+- cfec796: Update dependencies

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,13 +27,13 @@
   },
   "engineStrict": true,
   "publishConfig": {
-    "main": "./dist/lib.cjs.js",
-    "module": "./dist/lib.esm.js",
+    "main": "./dist/lib.cjs",
+    "module": "./dist/lib.mjs",
     "types": "./dist/lib.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/lib.esm.js",
-        "require": "./dist/lib.cjs.js"
+        "import": "./dist/lib.mjs",
+        "require": "./dist/lib.cjs"
       },
       "./*": "./*"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scale-codec/core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Low-level tools to perform serialization and deserialization via SCALE spec",
   "license": "Apache-2.0",
   "keywords": [
@@ -43,8 +43,8 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@scale-codec/enum": "workspace:^1.0.2",
-    "@scale-codec/util": "workspace:^1.0.0"
+    "@scale-codec/enum": "workspace:^1.1.0",
+    "@scale-codec/util": "workspace:^1.1.0"
   },
   "devDependencies": {
     "hada": "^0.0.8",

--- a/packages/definition-compiler/CHANGELOG.md
+++ b/packages/definition-compiler/CHANGELOG.md
@@ -1,167 +1,179 @@
 # @scale-codec/definition-compiler
 
+## 2.2.0
+
+### Minor Changes
+
+- e72d4de: Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`
+
+### Patch Changes
+
+- Updated dependencies [e72d4de]
+  - @scale-codec/enum@1.1.0
+  - @scale-codec/util@1.1.0
+
 ## 2.1.0
 
 ### Minor Changes
 
--   22042cf: **feat**: **BREAKING** add refs graph validation, and if it has unresolved references, compiler will throw
+- 22042cf: **feat**: **BREAKING** add refs graph validation, and if it has unresolved references, compiler will throw
 
 ### Patch Changes
 
--   42d05b4: **feat**: add `optimizeDyns` option to enable experimental optimization
+- 42d05b4: **feat**: add `optimizeDyns` option to enable experimental optimization
 
 ## 2.0.0
 
 ### Major Changes
 
--   1f92e19: **BREAKING**
+- 1f92e19: **BREAKING**
 
-    -   **What is the change**
+  - **What is the change**
 
-        Now compiled type consists from 1 entry that is a type and a variable simultaneously. Variable actually is a codec and **a factory** to create values.
+    Now compiled type consists from 1 entry that is a type and a variable simultaneously. Variable actually is a codec and **a factory** to create values.
 
-        You can see the new approach by looking at this example of compiled `VecU32` type.
+    You can see the new approach by looking at this example of compiled `VecU32` type.
 
-        **Before**:
+    **Before**:
 
-        ```ts
-        import { U32, VecCodec, Codec, createVecCodec } from '@scale-codec/definition-runtime'
+    ```ts
+    import { U32, VecCodec, Codec, createVecCodec } from '@scale-codec/definition-runtime'
 
-        export const VecU32: VecCodec<typeof U32> = createVecCodec('VecU32', U32)
-        ```
+    export const VecU32: VecCodec<typeof U32> = createVecCodec('VecU32', U32)
+    ```
 
-        **After**:
+    **After**:
 
-        ```ts
-        import { Opaque, U32, createVecCodec, Codec } from '@scale-codec/definition-runtime'
+    ```ts
+    import { Opaque, U32, createVecCodec, Codec } from '@scale-codec/definition-runtime'
 
-        interface VecU32 extends Opaque<number[], VecU32> {}
+    interface VecU32 extends Opaque<number[], VecU32> {}
 
-        const VecU32: Codec<VecU32> & ((actual: number[]) => VecU32) = createVecCodec('VecU32', U32)
+    const VecU32: Codec<VecU32> & ((actual: number[]) => VecU32) = createVecCodec('VecU32', U32)
 
-        export { VecU32 }
-        ```
+    export { VecU32 }
+    ```
 
-        -   You can use `VecU32` just as a type
-        -   You can use `VecU32` as codec, i.e. `VecU32.toBuffer(VecU32([1, 2, 3]))`
-        -   You can only pass data to `VecU32` codec only if you define it explicitly via factory (`VecU32([1, 2, 3])`) or with `as` keyword (`[1, 2, 3] as VecU32`). Thanks to `Opaque` type from `type-fest` library.
+    - You can use `VecU32` just as a type
+    - You can use `VecU32` as codec, i.e. `VecU32.toBuffer(VecU32([1, 2, 3]))`
+    - You can only pass data to `VecU32` codec only if you define it explicitly via factory (`VecU32([1, 2, 3])`) or with `as` keyword (`[1, 2, 3] as VecU32`). Thanks to `Opaque` type from `type-fest` library.
 
-    -   **Why the change was made**
+  - **Why the change was made**
 
-        There was no way to securely construct values and pass it to codecs - the task to infer types was too heavy for TypeScript to solve on huge namespaces. And there was no clear way to extract actual types from codecs, and you had to use something like `CodecValueEncodable<typeof VecU32>`
+    There was no way to securely construct values and pass it to codecs - the task to infer types was too heavy for TypeScript to solve on huge namespaces. And there was no clear way to extract actual types from codecs, and you had to use something like `CodecValueEncodable<typeof VecU32>`
 
-        New approach is more easy and secure to use.
+    New approach is more easy and secure to use.
 
-    -   **How you should update your code**
+  - **How you should update your code**
 
-        Compiler input schema is not changed, but you should update the usage of compiled output and the way how external modules are defined.
+    Compiler input schema is not changed, but you should update the usage of compiled output and the way how external modules are defined.
 
-        **Usage of compiled output**:
+    **Usage of compiled output**:
 
-        ```ts
-        import { VecU32 } from './compiled'
+    ```ts
+    import { VecU32 } from './compiled'
 
-        // Before
-        const data1 = VecU32.toBuffer([1, 2, 3])
+    // Before
+    const data1 = VecU32.toBuffer([1, 2, 3])
 
-        // After
-        const data2 = VecU32.toBuffer(VecU32([1, 2, 3]))
-        const data3 = VecU32.toBuffer([1, 2, 3] as VecU32) // or
-        ```
+    // After
+    const data2 = VecU32.toBuffer(VecU32([1, 2, 3]))
+    const data3 = VecU32.toBuffer([1, 2, 3] as VecU32) // or
+    ```
 
-        **External module format**:
+    **External module format**:
 
-        ```ts
-        // Before
+    ```ts
+    // Before
 
-        import { createBuilder, FragmentBuilder } from '@scale-codec/definition-runtime'
+    import { createBuilder, FragmentBuilder } from '@scale-codec/definition-runtime'
 
-        export const CustomNum: FragmentBuilder<number> = createBuilder('CustomNum', someEncodeFun, someDecodeFun)
+    export const CustomNum: FragmentBuilder<number> = createBuilder('CustomNum', someEncodeFun, someDecodeFun)
 
-        // After
+    // After
 
-        import { trackableCodec } from '@scale-codec/definition-runtime'
+    import { trackableCodec } from '@scale-codec/definition-runtime'
 
-        type CustomNum = string
+    type CustomNum = string
 
-        const CustomNum = trackableCodec<string>('CustomNum', someEncodeFun, someDecodeFun)
+    const CustomNum = trackableCodec<string>('CustomNum', someEncodeFun, someDecodeFun)
 
-        export { CustomNum }
-        ```
+    export { CustomNum }
+    ```
 
 ### Patch Changes
 
--   Updated dependencies [1f92e19]
-    -   @scale-codec/enum@1.0.2
+- Updated dependencies [1f92e19]
+  - @scale-codec/enum@1.0.2
 
 ## 1.0.0
 
 ### Major Changes
 
--   **BREAKING** - update compiler due to the slightly updated runtime package.
+- **BREAKING** - update compiler due to the slightly updated runtime package.
 
 ### Patch Changes
 
--   Updated dependencies
-    -   @scale-codec/util@1.0.0
+- Updated dependencies
+  - @scale-codec/util@1.0.0
 
 ## 0.8.1
 
 ### Patch Changes
 
--   27b7927: Add build status badge to the README
--   Updated dependencies [27b7927]
-    -   @scale-codec/util@0.1.3
+- 27b7927: Add build status badge to the README
+- Updated dependencies [27b7927]
+  - @scale-codec/util@0.1.3
 
 ## 0.8.0
 
 ### Minor Changes
 
--   31a546d: **breaking**: drop `createAliasBuilder` & `dynBuilder`, introduce `dynGetters` for both cases.
+- 31a546d: **breaking**: drop `createAliasBuilder` & `dynBuilder`, introduce `dynGetters` for both cases.
 
-    There were 2 problems:
+  There were 2 problems:
 
-    -   `DynBuilder` didn't support extended builders such as `ScaleEnumBuilder` with its own helpers to define variants.
-    -   `createAliasBuilder` didn't support the same thing and generally was like a stub for `DynBuilder`
+  - `DynBuilder` didn't support extended builders such as `ScaleEnumBuilder` with its own helpers to define variants.
+  - `createAliasBuilder` didn't support the same thing and generally was like a stub for `DynBuilder`
 
-    Now, it is solved with `dynGetters` that creates a Proxy to any object and dispatches its props in the moment when they are being got. It supports simple extensions over `FragmentBuilder` like `ScaleEnumBuilder`'s are. And now any aliases are closer to be "just another name for the object", except the fact that it will be a proxy to an object. Compiler now respects this approach.
+  Now, it is solved with `dynGetters` that creates a Proxy to any object and dispatches its props in the moment when they are being got. It supports simple extensions over `FragmentBuilder` like `ScaleEnumBuilder`'s are. And now any aliases are closer to be "just another name for the object", except the fact that it will be a proxy to an object. Compiler now respects this approach.
 
 ## 0.4.0
 
 ### Minor Changes
 
--   c78d861: **Breaking**:
+- c78d861: **Breaking**:
 
-    -   Runtime: new approach with `Fragment`, `FragmentBuilder` and others
-    -   Compiler: drop vue & prettier + new approach for new runtime
+  - Runtime: new approach with `Fragment`, `FragmentBuilder` and others
+  - Compiler: drop vue & prettier + new approach for new runtime
 
--   3441cdb: **Breaking**: definition for "external" types now uses `import` tag instead of `external`
+- 3441cdb: **Breaking**: definition for "external" types now uses `import` tag instead of `external`
 
 ### Patch Changes
 
--   26c9dd0: Update readme and `homepage` at `package.json`
--   334a28d: Add keywords to package.json
--   Updated dependencies [26c9dd0]
-    -   @scale-codec/util@0.1.2
+- 26c9dd0: Update readme and `homepage` at `package.json`
+- 334a28d: Add keywords to package.json
+- Updated dependencies [26c9dd0]
+  - @scale-codec/util@0.1.2
 
 ## 0.3.0
 
 ### Minor Changes
 
--   1904251: Update type exports and documentation
+- 1904251: Update type exports and documentation
 
 ### Patch Changes
 
--   07d0d6e: Hide `WithTMark` from public API; fix doc comment
+- 07d0d6e: Hide `WithTMark` from public API; fix doc comment
 
 ## 0.2.0
 
 ### Minor Changes
 
--   ac55aa8: feat: new optional feature - rollup single tuple into an alias of the inner type
--   a1b1a98: feat: support definitions for external types
--   4a77d16: feat: now it is possible to define codec aliases
+- ac55aa8: feat: new optional feature - rollup single tuple into an alias of the inner type
+- a1b1a98: feat: support definitions for external types
+- 4a77d16: feat: now it is possible to define codec aliases
 
 ### Patch Changes
 
--   cfec796: Update dependencies
+- cfec796: Update dependencies

--- a/packages/definition-compiler/package.json
+++ b/packages/definition-compiler/package.json
@@ -20,13 +20,13 @@
   "homepage": "https://soramitsu.github.io/scale-codec-js-library/",
   "main": "src/lib.ts",
   "publishConfig": {
-    "main": "./dist/lib.cjs.js",
-    "module": "./dist/lib.esm.js",
+    "main": "./dist/lib.cjs",
+    "module": "./dist/lib.mjs",
     "types": "./dist/lib.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/lib.esm.js",
-        "require": "./dist/lib.cjs.js"
+        "import": "./dist/lib.mjs",
+        "require": "./dist/lib.cjs"
       },
       "./*": "./*"
     }

--- a/packages/definition-compiler/package.json
+++ b/packages/definition-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scale-codec/definition-compiler",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "SCALE-codec types namespace definition compiler",
   "keywords": [
     "SCALE",
@@ -36,14 +36,15 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@scale-codec/enum": "workspace:^1.0.2",
-    "@scale-codec/util": "workspace:^1.0.0",
+    "@scale-codec/enum": "workspace:^1.1.0",
+    "@scale-codec/util": "workspace:^1.1.0",
     "immutable": "^4.0.0",
     "sort-es": "^1.4.6",
     "tarjan-graph": "^3.0.0"
   },
   "devDependencies": {
-    "@scale-codec/definition-runtime": "workspace:^2.0.0"
+    "@scale-codec/definition-runtime": "workspace:^2.2.0",
+    "jest-immutable-matchers": "^3.0.0"
   },
   "engines": {
     "node": ">16.8"

--- a/packages/definition-runtime/CHANGELOG.md
+++ b/packages/definition-runtime/CHANGELOG.md
@@ -1,128 +1,140 @@
 # @scale-codec/definition-runtime
 
+## 2.2.0
+
+### Minor Changes
+
+- e72d4de: Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`
+
+### Patch Changes
+
+- Updated dependencies [e72d4de]
+  - @scale-codec/core@1.1.0
+  - @scale-codec/util@1.1.0
+
 ## 2.0.0
 
 ### Major Changes
 
--   1f92e19: **BREAKING**: updated runtime for updated compiler. See related compiler's changelog
+- 1f92e19: **BREAKING**: updated runtime for updated compiler. See related compiler's changelog
 
 ### Patch Changes
 
--   Updated dependencies [1f92e19]
-    -   @scale-codec/core@1.0.1
+- Updated dependencies [1f92e19]
+  - @scale-codec/core@1.0.1
 
 ## 1.0.0
 
 ### Major Changes
 
--   **BREAKING**
+- **BREAKING**
 
-    -   **What is the change**
+  - **What is the change**
 
-        -   `Fragment`s are dropped - they produced a lot of performance overhead
-        -   Simple codecs built on top of the new performant `core` library
+    - `Fragment`s are dropped - they produced a lot of performance overhead
+    - Simple codecs built on top of the new performant `core` library
 
-    -   **Why the change was made**
+  - **Why the change was made**
 
-        Due to performance reasons.
+    Due to performance reasons.
 
 ### Patch Changes
 
--   Updated dependencies
--   Updated dependencies
-    -   @scale-codec/core@1.0.0
-    -   @scale-codec/util@1.0.0
+- Updated dependencies
+- Updated dependencies
+  - @scale-codec/core@1.0.0
+  - @scale-codec/util@1.0.0
 
 ## 0.8.2
 
 ### Patch Changes
 
--   54c0866: docs: clean README
+- 54c0866: docs: clean README
 
 ## 0.8.1
 
 ### Patch Changes
 
--   27b7927: Add build status badge to the README
--   Updated dependencies [27b7927]
-    -   @scale-codec/core@0.4.1
-    -   @scale-codec/util@0.1.3
+- 27b7927: Add build status badge to the README
+- Updated dependencies [27b7927]
+  - @scale-codec/core@0.4.1
+  - @scale-codec/util@0.1.3
 
 ## 0.8.0
 
 ### Minor Changes
 
--   31a546d: **breaking**: drop `createAliasBuilder` & `dynBuilder`, introduce `dynGetters` for both cases.
+- 31a546d: **breaking**: drop `createAliasBuilder` & `dynBuilder`, introduce `dynGetters` for both cases.
 
-    There were 2 problems:
+  There were 2 problems:
 
-    -   `DynBuilder` didn't support extended builders such as `ScaleEnumBuilder` with its own helpers to define variants.
-    -   `createAliasBuilder` didn't support the same thing and generally was like a stub for `DynBuilder`
+  - `DynBuilder` didn't support extended builders such as `ScaleEnumBuilder` with its own helpers to define variants.
+  - `createAliasBuilder` didn't support the same thing and generally was like a stub for `DynBuilder`
 
-    Now, it is solved with `dynGetters` that creates a Proxy to any object and dispatches its props in the moment when they are being got. It supports simple extensions over `FragmentBuilder` like `ScaleEnumBuilder`'s are. And now any aliases are closer to be "just another name for the object", except the fact that it will be a proxy to an object. Compiler now respects this approach.
+  Now, it is solved with `dynGetters` that creates a Proxy to any object and dispatches its props in the moment when they are being got. It supports simple extensions over `FragmentBuilder` like `ScaleEnumBuilder`'s are. And now any aliases are closer to be "just another name for the object", except the fact that it will be a proxy to an object. Compiler now respects this approach.
 
 ## 0.7.0
 
 ### Minor Changes
 
--   **feat**: add `defineUnwrap` helper to the generic `FragmentBuilder`
--   **feat**: add `variants` and `variantsUnwrapped` helpers to the Enum builders
+- **feat**: add `defineUnwrap` helper to the generic `FragmentBuilder`
+- **feat**: add `variants` and `variantsUnwrapped` helpers to the Enum builders
 
 ## 0.6.0
 
 ### Minor Changes
 
--   **feat**: Tracking API
+- **feat**: Tracking API
 
 ## 0.5.0
 
 ### Minor Changes
 
--   8890415: **breaking**: update int codecs due to breaking changes in core package
+- 8890415: **breaking**: update int codecs due to breaking changes in core package
 
 ### Patch Changes
 
--   Updated dependencies [56a9d2c]
--   Updated dependencies [8890415]
-    -   @scale-codec/core@0.4.0
+- Updated dependencies [56a9d2c]
+- Updated dependencies [8890415]
+  - @scale-codec/core@0.4.0
 
 ## 0.4.0
 
 ### Minor Changes
 
--   c78d861: **Breaking**:
+- c78d861: **Breaking**:
 
-    -   Runtime: new approach with `Fragment`, `FragmentBuilder` and others
-    -   Compiler: drop vue & prettier + new approach for new runtime
+  - Runtime: new approach with `Fragment`, `FragmentBuilder` and others
+  - Compiler: drop vue & prettier + new approach for new runtime
 
 ### Patch Changes
 
--   26c9dd0: Update readme and `homepage` at `package.json`
--   334a28d: Add keywords to package.json
--   Updated dependencies [26c9dd0]
--   Updated dependencies [97dfb7d]
--   Updated dependencies [6d26250]
--   Updated dependencies [97dfb7d]
--   Updated dependencies [ab6d899]
--   Updated dependencies [334a28d]
--   Updated dependencies [c78d861]
-    -   @scale-codec/core@0.3.0
-    -   @scale-codec/util@0.1.2
+- 26c9dd0: Update readme and `homepage` at `package.json`
+- 334a28d: Add keywords to package.json
+- Updated dependencies [26c9dd0]
+- Updated dependencies [97dfb7d]
+- Updated dependencies [6d26250]
+- Updated dependencies [97dfb7d]
+- Updated dependencies [ab6d899]
+- Updated dependencies [334a28d]
+- Updated dependencies [c78d861]
+  - @scale-codec/core@0.3.0
+  - @scale-codec/util@0.1.2
 
 ## 0.1.3
 
 ### Patch Changes
 
--   b427748: Add general package documentation
--   Updated dependencies [86cf787]
--   Updated dependencies [e1598bb]
--   Updated dependencies [a3d7d34]
-    -   @scale-codec/core@0.2.3
+- b427748: Add general package documentation
+- Updated dependencies [86cf787]
+- Updated dependencies [e1598bb]
+- Updated dependencies [a3d7d34]
+  - @scale-codec/core@0.2.3
 
 ## 0.1.2
 
 ### Patch Changes
 
--   cfec796: Update dependencies
--   Updated dependencies [cfec796]
-    -   @scale-codec/core@0.2.2
+- cfec796: Update dependencies
+- Updated dependencies [cfec796]
+  - @scale-codec/core@0.2.2

--- a/packages/definition-runtime/package.json
+++ b/packages/definition-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scale-codec/definition-runtime",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "Runtime for compiled result from @scale-codec/definition-compiler",
   "keywords": [
     "SCALE",
@@ -38,12 +38,12 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@scale-codec/core": "workspace:^1.0.1",
-    "@scale-codec/util": "workspace:^1.0.0",
+    "@scale-codec/core": "workspace:^1.1.0",
+    "@scale-codec/util": "workspace:^1.1.0",
     "fmt-subs": "^1.0.2",
     "type-fest": "^2.13.0"
   },
   "devDependencies": {
-    "@scale-codec/definition-compiler": "workspace:^2.0.0"
+    "@scale-codec/definition-compiler": "workspace:^2.2.0"
   }
 }

--- a/packages/definition-runtime/package.json
+++ b/packages/definition-runtime/package.json
@@ -22,13 +22,13 @@
   "homepage": "https://soramitsu.github.io/scale-codec-js-library/",
   "main": "src/lib.ts",
   "publishConfig": {
-    "main": "./dist/lib.cjs.js",
-    "module": "./dist/lib.esm.js",
+    "main": "./dist/lib.cjs",
+    "module": "./dist/lib.mjs",
     "types": "./dist/lib.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/lib.esm.js",
-        "require": "./dist/lib.cjs.js"
+        "import": "./dist/lib.mjs",
+        "require": "./dist/lib.cjs"
       },
       "./*": "./*"
     }

--- a/packages/enum/CHANGELOG.md
+++ b/packages/enum/CHANGELOG.md
@@ -1,86 +1,92 @@
 # @scale-codec/enum
 
+## 1.1.0
+
+### Minor Changes
+
+- e72d4de: Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`
+
 ## 1.0.2
 
 ### Patch Changes
 
--   1f92e19: **types**: extend `Enum.variant()` typing
+- 1f92e19: **types**: extend `Enum.variant()` typing
 
 ## 1.0.1
 
 ### Patch Changes
 
--   eeeb481: **fix**: fix typing for `.as()` return value
+- eeeb481: **fix**: fix typing for `.as()` return value
 
 ## 1.0.0
 
 ### Major Changes
 
--   **feat**: **BREAKING** `Enum` now uses new definitions approach.
+- **feat**: **BREAKING** `Enum` now uses new definitions approach.
 
-    For example, instead of:
+  For example, instead of:
 
-    ```ts
-    type OptNum = Enum<{
-        None: null
-        Some: { value: number }
-    }>
-    ```
+  ```ts
+  type OptNum = Enum<{
+    None: null
+    Some: { value: number }
+  }>
+  ```
 
-    it should be:
+  it should be:
 
-    ```ts
-    type OptNum = Enum<'None' | ['Some', number]>
-    ```
+  ```ts
+  type OptNum = Enum<'None' | ['Some', number]>
+  ```
 
-    This definition way is much more easier for TypeScript to handle, and it allows to avoid some constraints and auto-inference problems
+  This definition way is much more easier for TypeScript to handle, and it allows to avoid some constraints and auto-inference problems
 
--   **feat**: **BREAKING** `empty()` and `valuable()` static methods are replaced with a single `variant()` creation factory. It is type-safe and easy to use thanks to the new definitions approach.
+- **feat**: **BREAKING** `empty()` and `valuable()` static methods are replaced with a single `variant()` creation factory. It is type-safe and easy to use thanks to the new definitions approach.
 
-    For example, instead of:
+  For example, instead of:
 
-    ```ts
-    type OptNum = Option<number>
+  ```ts
+  type OptNum = Option<number>
 
-    const opt1: OptNum = Enum.empty('None')
-    const opt2: OptNum = Enum.valuable('Some', 42)
-    ```
+  const opt1: OptNum = Enum.empty('None')
+  const opt2: OptNum = Enum.valuable('Some', 42)
+  ```
 
-    it should be:
+  it should be:
 
-    ```ts
-    const opt3: OptNum = Enum.variant('None')
-    const opt4: OptNum = Enum.variant('Some', 42)
-    ```
+  ```ts
+  const opt3: OptNum = Enum.variant('None')
+  const opt4: OptNum = Enum.variant('Some', 42)
+  ```
 
 ## 0.2.2
 
 ### Patch Changes
 
--   b4c91cf: **feat**: better error messages when use `.as(tag)`
+- b4c91cf: **feat**: better error messages when use `.as(tag)`
 
 ## 0.2.1
 
 ### Patch Changes
 
--   27b7927: Add build status badge to the README
+- 27b7927: Add build status badge to the README
 
 ## 0.2.0
 
 ### Minor Changes
 
--   c78d861: **Breaking changes**:
+- c78d861: **Breaking changes**:
 
-    -   drop `create()` static method, add `valuable()` and `empty()` instead
-    -   update internal fields which are used by other packages
+  - drop `create()` static method, add `valuable()` and `empty()` instead
+  - update internal fields which are used by other packages
 
 ### Patch Changes
 
--   26c9dd0: Update readme and `homepage` at `package.json`
--   334a28d: Add keywords to package.json
+- 26c9dd0: Update readme and `homepage` at `package.json`
+- 334a28d: Add keywords to package.json
 
 ## 0.1.1
 
 ### Patch Changes
 
--   b79934e: Add more inline documentation
+- b79934e: Add more inline documentation

--- a/packages/enum/package.json
+++ b/packages/enum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scale-codec/enum",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Simple JavaScript abstraction around Rust Enums",
   "keywords": [
     "rust",

--- a/packages/enum/package.json
+++ b/packages/enum/package.json
@@ -18,13 +18,13 @@
   "homepage": "https://soramitsu.github.io/scale-codec-js-library/",
   "main": "src/lib.ts",
   "publishConfig": {
-    "main": "./dist/lib.cjs.js",
-    "module": "./dist/lib.esm.js",
+    "main": "./dist/lib.cjs",
+    "module": "./dist/lib.mjs",
     "types": "./dist/lib.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/lib.esm.js",
-        "require": "./dist/lib.cjs.js"
+        "import": "./dist/lib.mjs",
+        "require": "./dist/lib.cjs"
       },
       "./*": "./*"
     }

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -1,25 +1,31 @@
 # @scale-codec/util
 
+## 1.1.0
+
+### Minor Changes
+
+- e72d4de: Change build artifacts: `lib.cjs.js` → `lib.cjs`, `lib.esm.js` → `lib.mjs`
+
 ## 1.0.0
 
 ### Major Changes
 
--   **refactor**: **BREAKING** drop some unused methods, also refactor `concatBytes`
+- **refactor**: **BREAKING** drop some unused methods, also refactor `concatBytes`
 
 ## 0.1.3
 
 ### Patch Changes
 
--   27b7927: Add build status badge to the README
+- 27b7927: Add build status badge to the README
 
 ## 0.1.2
 
 ### Patch Changes
 
--   26c9dd0: Update readme and `homepage` at `package.json`
+- 26c9dd0: Update readme and `homepage` at `package.json`
 
 ## 0.1.1
 
 ### Patch Changes
 
--   7b92045: Update doc comments
+- 7b92045: Update doc comments

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -13,13 +13,13 @@
   "homepage": "https://soramitsu.github.io/scale-codec-js-library/",
   "main": "src/lib.ts",
   "publishConfig": {
-    "main": "./dist/lib.cjs.js",
-    "module": "./dist/lib.esm.js",
+    "main": "./dist/lib.cjs",
+    "module": "./dist/lib.mjs",
     "types": "./dist/lib.d.ts",
     "exports": {
       ".": {
-        "import": "./dist/lib.esm.js",
-        "require": "./dist/lib.cjs.js"
+        "import": "./dist/lib.mjs",
+        "require": "./dist/lib.cjs"
       },
       "./*": "./*"
     }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scale-codec/util",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared @scale-codec utilities",
   "license": "Apache-2.0",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,6 @@ importers:
       eslint-plugin-vue: ^9.0.1
       fs-extra: ^10.1.0
       jake: ^10.8.5
-      jest-immutable-matchers: ^3.0.0
       prettier: ^2.6.2
       prettier-eslint: ^15.0.1
       prettier-eslint-cli: ^6.0.1
@@ -51,7 +50,6 @@ importers:
       eslint-plugin-vue: 9.0.1_eslint@8.16.0
       fs-extra: 10.1.0
       jake: 10.8.5
-      jest-immutable-matchers: 3.0.0
       prettier: 2.6.2
       prettier-eslint: 15.0.1
       prettier-eslint-cli: 6.0.1
@@ -63,8 +61,8 @@ importers:
   e2e-spa:
     specifiers:
       '@esbuild-kit/cjs-loader': ^2.0.1
-      '@scale-codec/definition-compiler': workspace:^2.0.0
-      '@scale-codec/definition-runtime': workspace:^2.0.0
+      '@scale-codec/definition-compiler': workspace:^2.2.0
+      '@scale-codec/definition-runtime': workspace:^2.2.0
       '@types/jake': ^0.0.33
       '@vitejs/plugin-vue': ^2.3.3
       '@vue/compiler-sfc': ^3.2.36
@@ -130,8 +128,8 @@ importers:
 
   packages/core:
     specifiers:
-      '@scale-codec/enum': workspace:^1.0.2
-      '@scale-codec/util': workspace:^1.0.0
+      '@scale-codec/enum': workspace:^1.1.0
+      '@scale-codec/util': workspace:^1.1.0
       hada: ^0.0.8
       type-fest: ^2.13.0
     dependencies:
@@ -143,10 +141,11 @@ importers:
 
   packages/definition-compiler:
     specifiers:
-      '@scale-codec/definition-runtime': workspace:^2.0.0
-      '@scale-codec/enum': workspace:^1.0.2
-      '@scale-codec/util': workspace:^1.0.0
+      '@scale-codec/definition-runtime': workspace:^2.2.0
+      '@scale-codec/enum': workspace:^1.1.0
+      '@scale-codec/util': workspace:^1.1.0
       immutable: ^4.0.0
+      jest-immutable-matchers: ^3.0.0
       sort-es: ^1.4.6
       tarjan-graph: ^3.0.0
     dependencies:
@@ -157,12 +156,13 @@ importers:
       tarjan-graph: 3.0.0
     devDependencies:
       '@scale-codec/definition-runtime': link:../definition-runtime
+      jest-immutable-matchers: 3.0.0_immutable@4.1.0
 
   packages/definition-runtime:
     specifiers:
-      '@scale-codec/core': workspace:^1.0.1
-      '@scale-codec/definition-compiler': workspace:^2.0.0
-      '@scale-codec/util': workspace:^1.0.0
+      '@scale-codec/core': workspace:^1.1.0
+      '@scale-codec/definition-compiler': workspace:^2.2.0
+      '@scale-codec/util': workspace:^1.1.0
       fmt-subs: ^1.0.2
       type-fest: ^2.13.0
     dependencies:
@@ -3689,11 +3689,13 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /jest-immutable-matchers/3.0.0:
+  /jest-immutable-matchers/3.0.0_immutable@4.1.0:
     resolution: {integrity: sha512-FL4l0FecGx0ojOCE8xIoXxYXqBOGWBRiodjPRhMkiH9yYNvz78g26S/lCqsWAmFB+cN9mAU1+cNwe8X8mCe9Pw==}
     peerDependencies:
       immutable: '>=3.0.0'
       jest: '>=21.0.0'
+    dependencies:
+      immutable: 4.1.0
     dev: true
 
   /jiti/1.13.0:


### PR DESCRIPTION
Some context could be found here: https://github.com/hyperledger/iroha-javascript/pull/112